### PR TITLE
Vast v1.0.3 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Vast is a programming language that is syntactically simular to python.
 
-It is an interpreted, statically typed and non-object oriented language.
+It is an interpreted and dynamically typed programming language.
 
 Vast (as of currently) has **21** keywords, but as development continues, this number may be subject to change.
 - - -

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Discord](https://img.shields.io/badge/Discord-gray?style=flat-square&logo=discord&link=https://discord.gg/dDDrjSuxcg)](https://discord.gg/dDDrjSuxcg)
+
 # Vast Programming Language
 
 Vast is a programming language that is syntactically simular to python.

--- a/docs/debug_logs.md
+++ b/docs/debug_logs.md
@@ -1,0 +1,15 @@
+# Debug logs in Vast
+
+In your Vast interpreter, you have a variable that can be toggled on and off, and it's called the `debug_mode`.
+
+This exists within both the `interpret.py` and `xvastrunner.py` files. This mode allows for visualization of a more wide view of actions taken by the interpreter. 
+Almost every action taken by the interpreter has a log, and by switching on this view, it is possible to see beneath the curtains, and get to that pesky bug.
+
+---
+### How to read the logs
+If you just got started with Vast, and find the debug view a bit too complicated to understand, don't worry, because this documentation dives explicitly into the ins and outs of what each log mean.
+
+---
+### Color
+
+The logs are sorted into different colors that are unique to every type of log.

--- a/docs/debug_logs.md
+++ b/docs/debug_logs.md
@@ -13,3 +13,25 @@ If you just got started with Vast, and find the debug view a bit too complicated
 ### Color
 
 The logs are sorted into different colors that are unique to every type of log.
+
+- `\033[0;36m` Is a shade of dark turquoise, and is used to define when any function logic is invoked
+- `\033[0;32m` Is a dark green color, which used to define the normal output without debug mode
+- `\033[1;31m` Is bright red, used to define the end of a chunk or errors that may show up
+- `\033[1;33m` Is a dark yellow color, used to show the expanded packages
+- `\033[94m` Is sky blue, used to show the contents of expanded `__package__` files
+
+The remaining colors are either bound to be changed, or is as of currently, undefined.
+
+---
+### Chunks
+
+`chunk` are blocks of code that are executed within a statement, and the debugged outputs from that `chunk` are the inner workings of that function.
+
+As of currently, the following statements support `chunk`:
+
+> - `expand` <br>
+>   The `expand` statement's chunks look something like this: <br>
+>    `_______________________________ 1 Expanded Chunk(s) _______________________________`<br>
+>   **NOTE**: If the amount of expanded chunks exceed `1`, that means the interpreter has expanded the same package **twice**, and in the case that it does happen, please be sure to contact maintainers of Vast.
+<br>
+

--- a/index.vast
+++ b/index.vast
@@ -1,7 +1,7 @@
 expand example
-expand declorator
 expand efhef
-expand finished
+expand huh
+expand declorator
 
 print("Hello, World!")
 print("hi")

--- a/interpret.py
+++ b/interpret.py
@@ -231,7 +231,7 @@ class Interpret:
                 else:
                     if debug_mode:
                         print(f"\033[0;31mPackage '{packages}' does not exist\033[0m")
-                    raise FileNotFoundError("Package '" + packages + "' does not exist")
+                    raise ImportError("Package '" + packages + "' does not exist")
 
                 # Remove item from the list to avoid repeated imports
                 expanded_items.remove(packages)

--- a/interpret.py
+++ b/interpret.py
@@ -1,8 +1,9 @@
 import os
 from tokenize_lexer import convert_to_token
+# import xvastrunner
 
 # Set this too false to remove debug view
-debug_mode: bool = False
+debug_mode: bool = True
 
 # Read the config file to get the file name
 with open("config.xvast") as config_file:
@@ -11,6 +12,8 @@ with open("config.xvast") as config_file:
         if "runfile:" in line:
             runfile = line.split(":")
             file = runfile[1].strip()
+
+
 
 # Keywords and their corresponding tokens
 keywords = ["print", "(", ")", '"', "'", "{", "}", 'create', 'expand', 'export']

--- a/xvast_lexer.py
+++ b/xvast_lexer.py
@@ -1,0 +1,31 @@
+"""
+    Main Vast interpreter file
+
+    WARNING: DO NOT DELETE THIS FILE, DELETION OR ANY MODIFICATION OF THIS FILE MAY RESULT IN UNEXPECTED ERRORS
+"""
+
+import re
+
+class convert_to_token:
+    def __init__(self, keywords, file, tokens):
+        self.keywords = keywords
+        self.file = file
+        self.tokens = tokens
+
+    def tokenize(self):
+        tokenized_output = []
+
+        with open(self.file, "r") as file:
+            for line in file:
+                # split the details on the line
+                temp = re.split(rf"({'|'.join(map(re.escape, self.keywords))})", line)
+                detail = [ele for ele in temp if ele.strip()]
+
+                # tokenize the split list
+                for ele in detail:
+                    if ele in self.keywords:
+                        tokenized_output.append(self.tokens[self.keywords.index(ele)])
+                    else:
+                        tokenized_output.append(ele.strip())
+
+        return tokenized_output

--- a/xvastrunner.py
+++ b/xvastrunner.py
@@ -1,13 +1,18 @@
-from tokenize_lexer import convert_to_token
+from xvast_lexer import convert_to_token
 keywords = ["runfile", "export"]
 tokens = ["RUNFILE", "EXPORT"]
+
+debug_mode: bool = True
 
 def get_file(file):
     global interpret
     interpret = convert_to_token(keywords, file, tokens)
     global tokenized_output
     tokenized_output = list(interpret.tokenize())
-    print(tokenized_output)
+    if debug_mode:
+        print("Tokenized output: ", tokenized_output)
+    return tokenized_output
+
 class xvast:
     def __init__(self, tokenized_output):
         self.tokenized_output = tokenized_output
@@ -25,11 +30,16 @@ class xvast:
                 self.position += 1
 
     def _handle_runfile(self):
-        print(self.tokenized_output[self.position])
+
         if ":" in self.tokenized_output[self.position]:
             self.tokenized_output[self.position] = self.tokenized_output[self.position].replace(" ", "")
             self.tokenized_output[self.position] = self.tokenized_output[self.position].replace(":", "")
-            print(self.tokenized_output[self.position])
+            if debug_mode:
+                print(self.tokenized_output[self.position])
+
+            return self.tokenized_output[self.position]
+        else:
+            raise SyntaxError("Invalid Syntax")
 
 
 


### PR DESCRIPTION
Merging the v1.0.3 branch with the main branch, added some features to go with the 1.0.3 update:

### Additions
> - Added a lot of new `debug_mode` logs, by which now has color.
> - Added a `docs` directory, which contains the information on different aspects of Vast.
> - Added a `xvast` lexer, which now will be separate from the default lexer that the main Vast interpreter uses.
> - Added comments to `__package__.xvast` files.
> - Added documentation on `debug_mode`.


### Updates
> - Updated the `expand` statement a bit, and the complete version will be coming in v1.0.4.
---
Enjoy!